### PR TITLE
fix:변동률 계산 로직 수정

### DIFF
--- a/src/main/java/com/cleanengine/coin/chart/service/RealTimeTradeService.java
+++ b/src/main/java/com/cleanengine/coin/chart/service/RealTimeTradeService.java
@@ -42,20 +42,47 @@ public class RealTimeTradeService {
         // 변동률 계산
         double changeRate = 0.0;
         TradeEventDto previousTrade = previousTradeMap.get(ticker);
+        //참조 오류로 동일한 객체를 보고있어서 변동률 계산에 오류가 발생
+        log.debug("타임스탬프 비교 - 현재: {}, 이전: {}, 동일객체: {}",
+                tradeEventDto.getTimestamp(),
+                previousTrade != null ? previousTrade.getTimestamp() : "없음",
+                previousTrade == tradeEventDto);
 
-        if (previousTrade != null && previousTrade.getPrice() > 0) {
-            // 이전 거래 정보가 있는 경우 변동률 계산
-            double previousPrice = previousTrade.getPrice();
-            changeRate = ((currentPrice - previousPrice) / previousPrice) * 100;
-            log.debug("변동률 계산: 현재가={}, 이전가={}, 변동률={}%",
-                    currentPrice, previousPrice, changeRate);
+        // 이전 거래가 있고, 새로운 거래 데이터인 경우에만 변동률 계산
+        if (previousTrade != null && previousTrade.getPrice() > 0 && previousTrade != tradeEventDto) {
+            // 타임스탬프 비교로 새로운 거래인지 확인
+            if (previousTrade.getTimestamp() == null || tradeEventDto.getTimestamp() == null ||
+                    !previousTrade.getTimestamp().equals(tradeEventDto.getTimestamp())) {
+
+                double previousPrice = previousTrade.getPrice();
+                changeRate = ((currentPrice - previousPrice) / previousPrice) * 100;
+                log.debug("변동률 계산: 현재가={}, 이전가={}, 변동률={}%",
+                        currentPrice, previousPrice, changeRate);
+
+                // 새로운 거래 데이터 저장
+                previousTradeMap.put(ticker, new TradeEventDto(
+                        tradeEventDto.getTicker(),
+                        tradeEventDto.getSize(),
+                        tradeEventDto.getPrice(),
+                        tradeEventDto.getTimestamp()
+                ));
+            } else {
+                log.debug("동일한 타임스탬프의 거래 데이터가 다시 수신됨: {}", tradeEventDto.getTimestamp());
+            }
         } else {
-            log.debug("이전 거래 정보가 없어 변동률을 0으로 설정: {}", ticker);
+            if (previousTrade == null) {
+                log.debug("이전 거래 정보가 없어 변동률을 0으로 설정: {}", ticker);
+                // 첫 거래 데이터 저장 (복사본 저장)
+                previousTradeMap.put(ticker, new TradeEventDto(
+                        tradeEventDto.getTicker(),
+                        tradeEventDto.getSize(),
+                        tradeEventDto.getPrice(),
+                        tradeEventDto.getTimestamp()
+                ));
+            } else if (previousTrade == tradeEventDto) {
+                log.debug("동일한 거래 객체가 다시 수신됨 (참조 동일): {}", ticker);
+            }
         }
-
-        // 현재 거래 정보를 이전 거래 정보로 캐시에 저장
-        previousTradeMap.put(ticker, tradeEventDto);
-
         // RealTimeDataDto 객체 생성 및 반환
         return new RealTimeDataDto(
                 ticker,
@@ -66,4 +93,5 @@ public class RealTimeTradeService {
                 UUID.randomUUID().toString()
         );
     }
+
 }


### PR DESCRIPTION
<!-- Pull Request Template -->

# ✨ 작업내용
- [x] 변동률 계산 로직 수정  (https://github.com/CleanEngine/cleanengine-be/pull/46/commits/cd9357a99b5e97404020f84008cb3b46ef8bd2b1)
   - 이전 거래 정보를 “새 인스턴스”로 복사해서 저장하도록 변경  
   - 객체 동일 참조로 인한 변동률 0 반환 문제 해결  


# 🐞 이슈사항
- [x] 변동률 0으로 반환되는 이슈 발생 https://github.com/CleanEngine/cleanengine-be/issues/43

