### PR TITLE
Feat/chartdata fix

### DIFF
--- a/src/main/java/com/cleanengine/coin/chart/service/RealTimeDataPrevRateService.java
+++ b/src/main/java/com/cleanengine/coin/chart/service/RealTimeDataPrevRateService.java
@@ -39,7 +39,7 @@ public class RealTimeDataPrevRateService {
         Trade currentTrade = tradeRepository.findFirstByTickerOrderByTradeTimeDesc(ticker);
 
         if (yesterdayLastTrade == null || currentTrade == null) {
-            log.warn("전일 또는 현재 거래 데이터가 없습니다: {}", ticker);
+            log.debug("전일 또는 현재 거래 데이터가 없습니다: {}", ticker);
             return new PrevRateDto(ticker, 0.0, 0.0, 0.0, LocalDateTime.now());
         }
 

--- a/src/main/java/com/cleanengine/coin/trade/application/TradeBatchProcessor.java
+++ b/src/main/java/com/cleanengine/coin/trade/application/TradeBatchProcessor.java
@@ -97,6 +97,10 @@ public class TradeBatchProcessor implements ApplicationRunner {
 
     public TradeEventDto retrieveTradeEventDto(String ticker) {
         TradeQueueManager tradeQueueManager = this.tradeQueueManagers.get(ticker);
+        if (tradeQueueManager == null) {
+            return null;
+        }
+        
         TradeEventDto lastTradeEventDto = tradeQueueManager.getLastTradeEventDto();
 
         // 서비스 시작 후 체결 내역이 없으면 null 반환


### PR DESCRIPTION
# ✨ 작업내용
- [chore: 전일 체결내역 로그 수준 변경 (warn -> debug)](https://github.com/CleanEngine/cleanengine-be/commit/4833ea2644cd40d9e3d34cb020e343b38cfa52b5)
- [fix: 서비스 실행 후 tradeQueueManager 생성 전 호출 시 NullPointerException 에러 발생 조치](https://github.com/CleanEngine/cleanengine-be/commit/c23074f4b025852975685d1809a296b2927cd27b)

---

# ⚠️ 특별사항
- 전일 체결이 발생하지 않는 경우도 정상적인 상황일 수 있다고 판단해서 로그 레벨 warn -> debug 수정했습니다. 혹시 다른 의견이시면 코멘트 부탁드려요!
