### PR TITLE
fix: 운영환경에서 mariadb에 연결되지 않는 문제 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
     cookie:
       secure: true
   datasource:
-    url: jdbc:mariadb://localhost:3306/${MARIADB_DATABASE}
+    url: jdbc:mariadb://mariadb:3306/${MARIADB_DATABASE}
     driver-class-name: org.mariadb.jdbc.Driver
     username: ${MARIADB_USER}
     password: ${MARIADB_PASSWORD}


### PR DESCRIPTION
# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [x] spring.datasource.url 중 localhost -> mariadb로 변경(mariadb는 docker-compose.yml 파일에 등록된 이름) 73fc53e652f7845ed9a17ad5c8b4e81f7572f2e9