### PR TITLE
config: root 기본 레벨을 INFO로 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,6 +34,11 @@
             </rollingPolicy>
         </appender>
 
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+
         <logger name="com.cleanengine.coin" level="${LOG_LEVEL}">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
@@ -42,6 +47,10 @@
 
     <!-- local, dev 환경: 콘솔만 출력 -->
     <springProfile name="local,dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
         <logger name="com.cleanengine.coin" level="${LOG_LEVEL}">
             <appender-ref ref="CONSOLE"/>
         </logger>


### PR DESCRIPTION
# ✨ 작업내용
- [x] [config: root 기본 레벨을 INFO로 추가](https://github.com/CleanEngine/cleanengine-be/commit/061fb82f57a123ec493d10efcbeb51a2ad9a83da)  061fb82f57a123ec493d10efcbeb51a2ad9a83da

---

# ⚠️ 특별사항
- 저희 패키지만 로깅하면 되는 줄 알고 이전에 root를 제외시켰는데, DB 연결 등 에러가 보이지 않는 문제가 있네요.
  root 기본 로그 레벨인 INFO 로 등록해두었습니다.
