### PR TITLE
fix: 일시적으로 WorkingServerProfile 비활성화

### DIFF
--- a/src/main/java/com/cleanengine/coin/chart/controller/ChartDataController.java
+++ b/src/main/java/com/cleanengine/coin/chart/controller/ChartDataController.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
-@WorkingServerProfile
+//@WorkingServerProfile
 @RequiredArgsConstructor
 @Slf4j
 public class ChartDataController {


### PR DESCRIPTION
WorkingServerProfile을 ChartDataController에 적용시, bean 초기화 오류가 발생해 일시적으로 허용했습니다. 통합 테스트 전에 Scheduling 로직이 비활성화 될 수 있도록 재수정 필요할 것 같습니다.

