### PR TITLE
fix: 하락 추세 반영 시 power에 의해 volume이 음수가 되는 현상 개선

### DIFF
--- a/src/main/java/com/cleanengine/coin/realitybot/service/OrderGenerateService.java
+++ b/src/main/java/com/cleanengine/coin/realitybot/service/OrderGenerateService.java
@@ -117,10 +117,10 @@ public class OrderGenerateService {
                 if (deviation > 0.01) {
                     double power = trendLineRate * 100; // 3% → 3
                     if (trendLineRate < 0) {
-                        buyVolume *= 1.0 + power * 0.5; // 3% → 2.5배
+                        buyVolume *= 1.0 + Math.abs(power) * 0.5; // 3% → 2.5배
                         buyPrice = normalizeToUnit(apiVWAP * (1 + 0.002 * power)); // +0.6%
                     } else {
-                        sellVolume *= 1.0 + power * 0.5;
+                        sellVolume *= 1.0 + Math.abs(power) * 0.5;
                         sellPrice = normalizeToUnit(apiVWAP * (1 - 0.002 * power)); // -0.6%
                     }
                 }


### PR DESCRIPTION
# ✨ 작업내용
- [x] [하락 추세 반영 시 power에 의해 volume이 음수가 되는 현상 개선](https://github.com/CleanEngine/cleanengine-be/commit/453137cafcf441d1355e9ebcbb86516676690f94)  453137cafcf441d1355e9ebcbb86516676690f94
---


# 🐞 이슈사항
| 이슈 번호 | 제목 | 상태 |
| :-- | :-- | :-- |
| #060 | [BE] - 운영환경 매수 주문 잔량 부족 에러 지속발생 #60 | ✅ 임시 조치 |

---


# ⚠️ 특별사항
- @109an94 임시로 음수값 처리만 한 거라서, 상세 수치는 이후 봐주시면 감사하겠습니다!
