### PR TITLE
config: main 브랜치의 README 수정 시 재배포되는 현상 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: CI/CD Deploy
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
 
 jobs:
   build:


### PR DESCRIPTION
# ✨ 작업내용
- main 브랜치의 README 수정 시 재배포되는 현상 개선  21a6b52c64cc835c094f12d2aa3c39a51203204a
---



# ⚠️ 특별사항
<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
- paths-ignore를 추가하여 해당 파일은 push 이벤트 감지하지 않도록 변경했습니다.
