### PR TITLE
refactor:Object data 삭제

### DIFF
--- a/src/main/java/com/cleanengine/coin/chart/controller/ChartDataController.java
+++ b/src/main/java/com/cleanengine/coin/chart/controller/ChartDataController.java
@@ -2,10 +2,8 @@ package com.cleanengine.coin.chart.controller;
 
 
 import com.cleanengine.coin.chart.dto.RealTimeOhlcDto;
-import com.cleanengine.coin.chart.service.*;
 import com.cleanengine.coin.chart.service.ChartSubscriptionService;
 import com.cleanengine.coin.chart.service.RealTimeOhlcService;
-import com.cleanengine.coin.common.annotation.WorkingServerProfile;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/cleanengine/coin/chart/controller/PrevRateController.java
+++ b/src/main/java/com/cleanengine/coin/chart/controller/PrevRateController.java
@@ -1,13 +1,10 @@
 package com.cleanengine.coin.chart.controller;
 
-import com.cleanengine.coin.chart.dto.PrevRateDto;
 import com.cleanengine.coin.chart.service.ChartSubscriptionService;
-import com.cleanengine.coin.chart.service.RealTimeDataPrevRateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 @Controller

--- a/src/main/java/com/cleanengine/coin/chart/controller/RealTimeTradeController.java
+++ b/src/main/java/com/cleanengine/coin/chart/controller/RealTimeTradeController.java
@@ -23,7 +23,7 @@ public class RealTimeTradeController {
      * {ticker} 값을 받습니다.
      */
     @MessageMapping("/subscribe/realTimeTradeRate/{ticker}")
-    public void realTimeTradeRate(@DestinationVariable String ticker, Object data) {
+    public void realTimeTradeRate(@DestinationVariable String ticker) {
         chartSubscriptionService.subscribeRealTimeTradeRate(ticker);
     }
 }

--- a/src/main/java/com/cleanengine/coin/chart/controller/RealTimeTradeController.java
+++ b/src/main/java/com/cleanengine/coin/chart/controller/RealTimeTradeController.java
@@ -1,14 +1,11 @@
 package com.cleanengine.coin.chart.controller;
 
-import com.cleanengine.coin.chart.dto.RealTimeDataDto;
+
 import com.cleanengine.coin.chart.service.ChartSubscriptionService;
-import com.cleanengine.coin.chart.service.RealTimeTradeService;
-import com.cleanengine.coin.chart.service.WebsocketSendService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 @Controller

--- a/src/main/java/com/cleanengine/coin/chart/service/RealTimeDataPrevRateService.java
+++ b/src/main/java/com/cleanengine/coin/chart/service/RealTimeDataPrevRateService.java
@@ -6,7 +6,6 @@ import com.cleanengine.coin.chart.repository.RealTimeTradeRepository;
 import com.cleanengine.coin.trade.entity.Trade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/cleanengine/coin/chart/service/RealTimeTradeService.java
+++ b/src/main/java/com/cleanengine/coin/chart/service/RealTimeTradeService.java
@@ -2,7 +2,6 @@ package com.cleanengine.coin.chart.service;
 
 import com.cleanengine.coin.chart.dto.RealTimeDataDto;
 import com.cleanengine.coin.chart.dto.TradeEventDto;
-import com.cleanengine.coin.chart.handler.TradeEventHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/cleanengine/coin/chart/service/WebsocketSendService.java
+++ b/src/main/java/com/cleanengine/coin/chart/service/WebsocketSendService.java
@@ -1,6 +1,5 @@
 package com.cleanengine.coin.chart.service;
 
-import com.cleanengine.coin.chart.dto.PrevRateDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;


### PR DESCRIPTION
# ✨ 작업내용
- [x] 기존의 스케쥴 방식의  실시간 데이터(직전데이터와 비교하여 등락율 포함하는)  차트에 보내는 방식을 이벤트 리스너 방식으로 변경
- [x] 기존의 스케쥴 방식의  실시간 데이터(전날 종가와 비교하여 변동률 포함 데이터)  차트에 보내는 방식을 이벤트 리스너 방식으로 변경
- [x]  테스트시 실시간 데이터가 안넘어오는점 발견해서 수정 

| # | 이슈 내용 | 상태 |
|---|---|---|
| #000 | 예시 이슈 | ✅ 해결 |
| #96 | [Trade가 null로 받아와지는 이슈 발견](https://github.com/CleanEngine/cleanengine-be/issues/96) | 완료 |
