### PR TITLE
config: 패키지의 로그가 root 로그에도 포함되어 2번씩 출력되던 현상 개선

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -39,7 +39,7 @@
             <appender-ref ref="FILE"/>
         </root>
 
-        <logger name="com.cleanengine.coin" level="${LOG_LEVEL}">
+        <logger name="com.cleanengine.coin" level="${LOG_LEVEL}" additivity="false">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
         </logger>
@@ -51,7 +51,7 @@
             <appender-ref ref="CONSOLE"/>
         </root>
 
-        <logger name="com.cleanengine.coin" level="${LOG_LEVEL}">
+        <logger name="com.cleanengine.coin" level="${LOG_LEVEL}" additivity="false">
             <appender-ref ref="CONSOLE"/>
         </logger>
     </springProfile>


### PR DESCRIPTION
<!-- Pull Request Template -->

# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [x] [config: 패키지의 로그가 root 로그에도 포함되어 2번씩 출력되던 현상 개선](https://github.com/CleanEngine/cleanengine-be/commit/4811455e09325805bece0bdd936dc2e2fa31f4ae)  4811455e09325805bece0bdd936dc2e2fa31f4ae
---

<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
- 동일 로그가 두 번씩 나오고 있었네요 ㅋㅋ
- `additivity="false"`로 설정된 패키지 로거의 로그는 root로 전달되지 않는다고 합니다.
