### PR TITLE
config: bastion host를 통해 배포되도록 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,10 +53,10 @@ jobs:
       - name: Connect to cloud server and run Docker commands
         uses: appleboy/ssh-action@v1.2.2
         with:
-          host: ${{secrets.BACKEND_HOST}}
+          host: ${{secrets.CLOUD_HOST}}
           username: ${{secrets.CLOUD_USERNAME}}
           key: ${{secrets.CLOUD_SECRET_KEY}}
           port: ${{secrets.CLOUD_PORT}}
           script: |
             cd ~
-            /bin/bash run_springboot.sh
+            /bin/bash deploy_spring.sh


### PR DESCRIPTION
(spring 서버를 public -> private 서브넷으로 이동했으므로 그에 따라 설정을 변경함)

<!-- Pull Request Template -->

# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [x] [config: bastion host를 통해 배포되도록 변경](https://github.com/CleanEngine/cleanengine-be/commit/b3f3819b961e2b1320dbba292581ca8a8f70f9b3)  b3f3819b961e2b1320dbba292581ca8a8f70f9b3

---


# ⚠️ 특별사항
<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
- spring 서버를 private 서브넷으로 변경해서 자동 배포를 위해 설정 및 리버스프록시 인스턴스 내부 스크립트 생성하였습니다.
- codeDeploy와 SSM 등 다른 방식들과 비교하다가, 그냥 bastion host에서 셸스크립트 실행하는 방식이 저희에게는 제일 맞는 방식 같아서 이렇게 적용했어요~
