### PR TITLE
fix: reuse jwtparser in JWTUtil

### DIFF
--- a/src/main/java/com/cleanengine/coin/user/login/application/JWTUtil.java
+++ b/src/main/java/com/cleanengine/coin/user/login/application/JWTUtil.java
@@ -1,6 +1,7 @@
 package com.cleanengine.coin.user.login.application;
 
 
+import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -15,19 +16,22 @@ public class JWTUtil {
 
     private final SecretKey secretKey;
 
+    private final JwtParser jwtParser;
+
     public JWTUtil(@Value("${spring.jwt.secret}") String secret) {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        jwtParser = Jwts.parser().verifyWith(secretKey).build();
     }
 
     public Integer getUserId(String token) {
 
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Integer.class);
+        return jwtParser.parseSignedClaims(token).getPayload().get("userId", Integer.class);
 
     }
 
     public Boolean isExpired(String token) {
 
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+        return jwtParser.parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
     public String createJwt(Integer userId, Long expiredMs) {


### PR DESCRIPTION
3차 고도화 때 변경사항 중 일부인데 늦게나마 반영합니다.

JwtParser가 재사용이 될 수 있으나 적용되지 않았던 부분을 수정했습니다
생성 자체에는 큰 문제가 없을 수 있으나, JwtParser는 재생성시 동적으로 클래스를 로드하기 때문에, 로드 중 lock이 걸렸었습니다. 

<img width="720" alt="jwtparser 병목" src="https://github.com/user-attachments/assets/5ac54456-7a83-4aed-ae78-5542e780130c" />

<!-- Pull Request Template -->

# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [x] jwtparser 재사용되도록 수정
---


# ⚠️ 특별사항
<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
- jwt 토큰 발급시에 호출하는 Jwts.builder는 Jwts.parser와 달리 성능이슈가 없다고 합니다.

