### PR TITLE
fix: 봇 주문 취소 서비스의 에러가 상위영역으로 전파되지 않도록 수정

### DIFF
--- a/src/main/java/com/cleanengine/coin/realitybot/service/BotOrderCancelService.java
+++ b/src/main/java/com/cleanengine/coin/realitybot/service/BotOrderCancelService.java
@@ -26,7 +26,13 @@ public class BotOrderCancelService {
         List<AssetInfo> assetInfos = assetService.getAllAssetInfos();
 
         for(AssetInfo assetInfo : assetInfos){
-            executorService.submit(() -> cancelBotLimitOrder(cancelRate, assetInfo.ticker()));
+            executorService.submit(() -> {
+                        try {
+                            cancelBotLimitOrder(cancelRate, assetInfo.ticker());
+                        } catch (Exception e) {
+                            log.error("봇 주문 취소중 에러 발생", e);
+                        }
+            });
         }
     }
 
@@ -37,7 +43,11 @@ public class BotOrderCancelService {
                 botOrderCountNeededToBeCanceled, ticker);
 
         for(BotOrderInfo botOrderInfo : orderIdsNeededToBeCanceled){
-            cancelEachOrder(botOrderInfo);
+            try{
+                cancelEachOrder(botOrderInfo);
+            } catch (IllegalStateException e) {
+                log.warn("해당 봇 주문은 이미 취소 됨 : {}", botOrderInfo.orderId());
+            }
         }
     }
 


### PR DESCRIPTION
봇 주문 취소 scheduler에서 try catch로 exception을 소비하고 있었으나, ticker별로 비동기적으로 동작하는 취소 주문에서 나온 Exception을 handling하지 못했었습니다. 별도의 스레드 내에서 처리되는 로직에 대해 각각 exception handling 영역을 추가했습니다.

<!-- Pull Request Template -->

# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [x] 봇 주문 취소 비동기 호출 영역 try catch로 handling
---


# 🐞 이슈사항
<!-- 해결했거나 논의가 필요한 이슈 번호‧내용을 적어주세요 -->

---


# ⚠️ 특별사항
<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
- 이미 취소가 된 주문에 대해 취소가 이루어지는 것은 단순히 해당 취소를 처리하지 않으면 되기 때문에, try catch로 처리했습니다.
- 하지만, 간헐적으로 한 주문에 대한 동시 취소가 발생하는 원인은 아직 파악중입니다.
