### PR TITLE
fix: allowed origin 설정 반영되도록 변경

### DIFF
--- a/src/main/java/com/cleanengine/coin/configuration/SecurityConfig.java
+++ b/src/main/java/com/cleanengine/coin/configuration/SecurityConfig.java
@@ -34,6 +34,9 @@ public class SecurityConfig {
     @Value("${frontend.url}")
     private String frontendUrl;
 
+    @Value("${spring.security.allowed-origins}")
+    private List<String> allowedOrigins;
+
     public SecurityConfig(CustomOAuth2UserService customOAuth2UserService,
                           CustomSuccessHandler customSuccessHandler, JWTUtil jwtUtil, EndpointConfig endpointConfig) {
         this.customOAuth2UserService = customOAuth2UserService;
@@ -45,12 +48,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         String frontendBaseUrl = buildBaseUrl(new URI(frontendUrl));
+        allowedOrigins.add(frontendBaseUrl);
 
         http
                 .cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
                     CorsConfiguration configuration = new CorsConfiguration();
 
-                    configuration.setAllowedOrigins(List.of(frontendBaseUrl,"http://localhost:63343"));
+                    configuration.setAllowedOrigins(allowedOrigins);
                     configuration.setAllowedMethods(Collections.singletonList("*"));
                     configuration.setAllowCredentials(true);
                     configuration.setAllowedHeaders(Collections.singletonList("*"));


### PR DESCRIPTION
<!-- Pull Request Template -->

# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [x] allowed origin 설정 반영되도록 변경
---


# ⚠️ 특별사항
<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
- application-*.yml 의 frontend.url 에 따라서만 CORS 허용이 되던 것을,
  spring.security.allowed-origins 값 전체에 허용되도록 변경했습니다.
  이제와서지만 ㅋㅋㅋ 편하게 개발 고고
- 그럼 기존 spring.security.allowed-origins 은 왜 만들었냐? 하실텐데
  웹소켓에서 쓰고 있었습니다
