### PR TITLE
config: 프론트엔드 로컬 빌드파일 실행 프로필 추가

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,30 @@
+spring:
+  config:
+    import: optional:file:./local.properties
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: false
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+    cookie:
+      secure: false
+
+frontend:
+  url: "http://localhost:3000/callback"
+


### PR DESCRIPTION
프론트엔드 빌드파일 실행 url localhost:3000에 대응하는 프로필(application-local)을 추가했습니다.

기존 application-dev 프로필은 소셜로그인시 무조건 localhost:5173으로 redirect하여 프론트엔드 빌트 버전(locahost:3000)에는 대응되지 않아 해당 프로필을 추가했습니다.

# ✨ 작업내용
- [x] application-local 추가 