### PR TITLE
Feat/chart realtime fix

### DIFF
--- a/src/main/java/com/cleanengine/coin/chart/controller/ChartDataController.java
+++ b/src/main/java/com/cleanengine/coin/chart/controller/ChartDataController.java
@@ -4,12 +4,10 @@ package com.cleanengine.coin.chart.controller;
 import com.cleanengine.coin.chart.dto.RealTimeOhlcDto;
 import com.cleanengine.coin.chart.service.ChartSubscriptionService;
 import com.cleanengine.coin.chart.service.RealTimeOhlcService;
-import com.cleanengine.coin.common.annotation.WorkingServerProfile;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -17,7 +15,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
-@WorkingServerProfile
 @RequiredArgsConstructor
 @Slf4j
 public class ChartDataController {
@@ -33,7 +30,7 @@ public class ChartDataController {
     /**
      * 1초마다 실행 - 실시간 OHLC 데이터 전송
      */
-    @Scheduled(fixedRate = 1000)
+//    @Scheduled(fixedRate = 1000)
     public void publishRealTimeOhlc() {
         try {
             log.debug("△ 실시간 OHLC 데이터 스케줄러 실행");

--- a/src/main/java/com/cleanengine/coin/order/adapter/in/web/asset/AssetController.java
+++ b/src/main/java/com/cleanengine/coin/order/adapter/in/web/asset/AssetController.java
@@ -4,6 +4,7 @@ import com.cleanengine.coin.common.response.ApiResponse;
 import com.cleanengine.coin.order.application.dto.AssetInfo;
 import com.cleanengine.coin.order.application.AssetService;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ public class AssetController {
         return ApiResponse.success(assetService.getAssetInfo(ticker), HttpStatus.OK).toResponseEntity();
     }
 
+    @Operation(summary = "모든 종목 정보를 불러옵니다.")
     @GetMapping("/api/asset")
     public ResponseEntity<ApiResponse<AssetInfos>> getAllAsset() {
         List<AssetInfo> assetInfoList = assetService.getAllAssetInfos();

--- a/src/main/java/com/cleanengine/coin/order/application/AssetService.java
+++ b/src/main/java/com/cleanengine/coin/order/application/AssetService.java
@@ -1,5 +1,6 @@
 package com.cleanengine.coin.order.application;
 
+import com.cleanengine.coin.chart.repository.RealTimeTradeRepository;
 import com.cleanengine.coin.common.error.DomainValidationException;
 import com.cleanengine.coin.order.adapter.out.persistentce.asset.AssetCacheRepository;
 import com.cleanengine.coin.order.adapter.out.persistentce.asset.AssetRepository;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.FieldError;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,6 +24,7 @@ public class AssetService {
     private final AssetRepository assetRepository;
     private final AssetCacheRepository assetCacheRepository;
     private final TradeRepository tradeRepository;
+    private final RealTimeTradeRepository realTimeTradeRepository;
 
     private final ConcurrentHashMap<String, Double> currentPriceCache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Asset> assetCache = new ConcurrentHashMap<>();
@@ -41,18 +45,30 @@ public class AssetService {
     }
 
     public AssetInfo getAssetInfo(String ticker){
-        Optional<Asset> assetOpt = getAsset(ticker);
-        if(assetOpt.isEmpty()){
-           throw new DomainValidationException(
-                   String.format("Asset %s not found", ticker),
-                   List.of(new FieldError("Asset", "ticker", "Asset not found")));
+        Asset asset = this.getAsset(ticker).orElseThrow(() -> new DomainValidationException(
+                String.format("Asset %s not found", ticker),
+                List.of(new FieldError("Asset", "ticker", "Asset not found"))));
+
+        Double currentPrice = this.getCurrentPrice(ticker);
+        Double changeRate = null;
+        if (currentPrice != null) {
+            changeRate = getChangeRate(ticker, currentPrice);
         }
 
-        return AssetInfo.from(assetOpt.get());
+        return AssetInfo.from(asset, currentPrice, changeRate);
+    }
+
+    private Double getChangeRate(String ticker, Double currentPrice) {
+        LocalDateTime yesterday = LocalDate.now().minusDays(1).atStartOfDay();
+        LocalDateTime today = LocalDate.now().atStartOfDay().minusNanos(1);
+        Trade prevTrade = realTimeTradeRepository.findFirstByTickerAndTradeTimeBetweenOrderByTradeTimeDesc(ticker, yesterday, today);
+        if (prevTrade == null) { return null; }
+
+        return (currentPrice - prevTrade.getPrice()) / prevTrade.getPrice() * 100;
     }
 
     public List<AssetInfo> getAllAssetInfos(){
-        return assetRepository.findAll().stream().map(AssetInfo::from).toList();
+        return assetRepository.findAll().stream().map(asset -> getAssetInfo(asset.getTicker())).toList();
     }
 
     public List<String> getAllTickers() {

--- a/src/main/java/com/cleanengine/coin/order/application/dto/AssetInfo.java
+++ b/src/main/java/com/cleanengine/coin/order/application/dto/AssetInfo.java
@@ -2,16 +2,31 @@ package com.cleanengine.coin.order.application.dto;
 
 import com.cleanengine.coin.order.domain.Asset;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.nio.charset.StandardCharsets;
 
 @JsonPropertyOrder({"ticker", "name"})
 public record AssetInfo(
+
+        @Schema(description = "종목 티커", example = "BTC")
         String ticker,
+
+        @Schema(description = "종목명", example = "비트코인")
         String name,
-        String svgIconBase64
-){
-    public static AssetInfo from(Asset asset){
+
+        @Schema(description = "아이콘 SVG(base64)")
+        String svgIconBase64,
+
+        @Schema(description = "현재가(체결내역 없으면 null)", example = "161000000")
+        Double currentPrice,
+
+        @Schema(description = "변동률(전일 체결내역 없으면 null)", example = "1.2")
+        Double changeRate
+
+) {
+
+    public static AssetInfo from(Asset asset, Double currentPrice, Double changeRate){
         byte[] iconBytes = asset.getIcon();
 
         String iconStr = null;
@@ -20,6 +35,7 @@ public record AssetInfo(
             iconStr = new String(iconBytes, StandardCharsets.UTF_8);
         }
 
-        return new AssetInfo(asset.getTicker(), asset.getName(), iconStr);
+        return new AssetInfo(asset.getTicker(), asset.getName(), iconStr, currentPrice, changeRate);
     }
+
 }

--- a/src/main/java/com/cleanengine/coin/trade/entity/Trade.java
+++ b/src/main/java/com/cleanengine/coin/trade/entity/Trade.java
@@ -1,8 +1,10 @@
 package com.cleanengine.coin.trade.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -21,8 +23,7 @@ public class Trade {
     @Column(name = "ticker", nullable = false)
     private String ticker;
 
-    @Column(name = "trade_time", nullable = false)
-    @CreationTimestamp
+    @Column(name = "trade_time", nullable = false, updatable = false)
     private LocalDateTime tradeTime;
 
     @Column(name = "buy_user_id", nullable = false)

--- a/src/test/java/com/cleanengine/coin/order/adapter/in/AssetControllerTest.java
+++ b/src/test/java/com/cleanengine/coin/order/adapter/in/AssetControllerTest.java
@@ -25,7 +25,7 @@ public class AssetControllerTest extends ControllerTest {
     @WithCustomMockUser
     public void findAll() throws Exception {
         when(assetService.getAllAssetInfos())
-                .thenReturn(List.of(new AssetInfo("BTC", "비트코인", null)));
+                .thenReturn(List.of(new AssetInfo("BTC", "비트코인", null, null, null)));
 
         String responseStr = performGet("/api/asset")
                 .andExpect(status().isOk())
@@ -41,7 +41,7 @@ public class AssetControllerTest extends ControllerTest {
     @WithCustomMockUser
     public void findAsset() throws Exception {
         when(assetService.getAssetInfo("BTC"))
-                .thenReturn(new AssetInfo("BTC", "비트코인", null));
+                .thenReturn(new AssetInfo("BTC", "비트코인", null, null, null));
 
         String responseStr = performGet("/api/asset/BTC")
                 .andExpect(status().isOk())

--- a/src/test/java/com/cleanengine/coin/order/application/AssetServiceIntegrationTest.java
+++ b/src/test/java/com/cleanengine/coin/order/application/AssetServiceIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.cleanengine.coin.order.application;
+
+import com.cleanengine.coin.chart.repository.RealTimeTradeRepository;
+import com.cleanengine.coin.order.application.dto.AssetInfo;
+import com.cleanengine.coin.trade.entity.Trade;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AssetService H2 통합 테스트")
+@ActiveProfiles({"dev", "it", "h2-mem"})
+@Transactional
+@SpringBootTest
+class AssetServiceIntegrationTest {
+
+    @Autowired
+    AssetService assetService;
+
+    @Autowired
+    RealTimeTradeRepository realTimeTradeRepository;
+
+    @DisplayName("모든 종목 정보를 조회한다.")
+    @Test
+    void getAllAssetInfos() {
+        // given
+        LocalDateTime yesterday = LocalDate.now().minusDays(1).atStartOfDay().plusHours(12);
+        LocalDateTime today = LocalDate.now().atStartOfDay().plusHours(12);
+        Trade prevTrumpTrade = Trade.of("TRUMP", yesterday, 2, 1, 10000.0, 1.0);
+        Trade todayTrumpTrade = Trade.of("TRUMP", today, 2, 1, 20000.0, 1.0);
+        realTimeTradeRepository.saveAll(List.of(prevTrumpTrade, todayTrumpTrade));
+        realTimeTradeRepository.flush();
+
+        // when
+        List<AssetInfo> allAssetInfos = assetService.getAllAssetInfos();
+        AssetInfo trumpAsset = null;
+        for (AssetInfo assetInfo : allAssetInfos) {
+            if (assetInfo.ticker().equals("TRUMP")) trumpAsset = assetInfo;
+        }
+
+        // then
+        assertThat(trumpAsset).isNotNull()
+                .extracting("ticker", "changeRate", "currentPrice")
+                .containsExactly("TRUMP", 100.0, 20000.0);
+
+    }
+
+    @DisplayName("전날 체결내역이 없는 경우 변동률 null을 반환한다.")
+    @Test
+    void getAllAssetInfosWithoutChangeRate() {
+        // given
+        LocalDateTime today = LocalDate.now().atStartOfDay().plusHours(12);
+        Trade todayTrumpTrade = Trade.of("TRUMP", today, 2, 1, 20000.0, 1.0);
+        realTimeTradeRepository.saveAll(List.of(todayTrumpTrade));
+        realTimeTradeRepository.flush();
+
+        // when
+        List<AssetInfo> allAssetInfos = assetService.getAllAssetInfos();
+        AssetInfo trumpAsset = null;
+        for (AssetInfo assetInfo : allAssetInfos) {
+            if (assetInfo.ticker().equals("TRUMP")) trumpAsset = assetInfo;
+        }
+
+        // then
+        assertThat(trumpAsset).isNotNull()
+                .extracting("ticker", "changeRate", "currentPrice")
+                .containsExactly("TRUMP", null, 20000.0);
+    }
+
+}


### PR DESCRIPTION
<!-- Pull Request Template -->

# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [x] [종목 정보 전송 시 현재가, 변동률 전송하도록 변경](https://github.com/CleanEngine/cleanengine-be/commit/303d2efd79269a6a3497b43631da4ccd5bd297f1)
---


# ⚠️ 특별사항
<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
- @BHyeonKim 일단 가상화폐 리스트(/api/asset) 부분만 작업했는데 병합하시고 테스트 부탁드려요~
  전날 거래가 없었으면 변동률 null, 체결내역이 아예 없으면 현재가도 null로 전송합니다.
