### PR TITLE
fix: 페이지네이션 빈 orderlist 반환

### DIFF
--- a/src/main/java/com/cleanengine/coin/mypage/controller/OrderListController.java
+++ b/src/main/java/com/cleanengine/coin/mypage/controller/OrderListController.java
@@ -18,7 +18,7 @@ public class OrderListController {
     private final OrderListService orderListService;
     @GetMapping("/trades")
     public ResponseEntity<ApiResponse<PagedOrderListDto>> getOrderList(@AuthenticationPrincipal CustomOAuth2User user,
-                                                                            @RequestParam(defaultValue = "0") int page,
+                                                                            @RequestParam(defaultValue = "1") int page,
                                                                             @RequestParam(defaultValue = "10") int size,
                                                                             @RequestParam(defaultValue = "false") boolean settled) {
         Integer userId = user.getUserId();

--- a/src/main/java/com/cleanengine/coin/mypage/controller/RankingController.java
+++ b/src/main/java/com/cleanengine/coin/mypage/controller/RankingController.java
@@ -27,7 +27,7 @@ public class RankingController {
     }
 
     @GetMapping("/all")
-    public ResponseEntity<ApiResponse<PagedRankingsDto>> getAllRanking(@RequestParam(defaultValue = "0") int page,
+    public ResponseEntity<ApiResponse<PagedRankingsDto>> getAllRanking(@RequestParam(defaultValue = "1") int page,
                                                                        @RequestParam(defaultValue = "10") int size) {
         PagedRankingsDto rankingDtos = rankingSchedulerService.getAllRanking(page,size);
         return ApiResponse.success(rankingDtos, HttpStatus.OK).toResponseEntity();

--- a/src/main/java/com/cleanengine/coin/mypage/service/OrderListService.java
+++ b/src/main/java/com/cleanengine/coin/mypage/service/OrderListService.java
@@ -28,7 +28,8 @@ public class OrderListService {
 
     public PagedOrderListDto getOrderList(Integer userId, int currentPage, int pageSize, boolean settled) {//todo cursortradetime, long cursorid, int pageisze 받기
         //커서기반에서 오프셋 기반으로 변경
-        PageRequest pageRequest = PageRequest.of(currentPage, pageSize, Sort.by(Sort.Direction.DESC,"createdAt","id"));
+        int adjustedPage = currentPage - 1;
+        PageRequest pageRequest = PageRequest.of(adjustedPage, pageSize, Sort.by(Sort.Direction.DESC,"createdAt","id"));
         List<BuyOrder> buyOrders;
         List<SellOrder> sellOrders;
         long totalBuyOrders;

--- a/src/main/java/com/cleanengine/coin/mypage/service/RankingSchedulerService.java
+++ b/src/main/java/com/cleanengine/coin/mypage/service/RankingSchedulerService.java
@@ -80,19 +80,21 @@ public class RankingSchedulerService {
         int totalPages = (int)Math.ceil((double)totalElements / size);
 
         //유효성
-        if (page<0) page = 0;
+        int adjustedPage = page -1;
+
+        if (adjustedPage<0) adjustedPage = 0;
         if (size<=0) size = 10;
-        if (page >= totalPages && totalPages > 0) {
-            page = totalPages - 1; //마지막 페이지 넘어가기 방어
+        if (adjustedPage >= totalPages && totalPages > 0) {
+            adjustedPage = totalPages - 1; //마지막 페이지 넘어가기 방어
             }
 
 
         //유저가 없으면 빈 배열
-        if (totalElements == 0 || page >= totalPages) { // +page 요청 수 넘어가면 추가 방어
+        if (totalElements == 0) { // +page 요청 수 넘어가면 추가 방어
             return new PagedRankingsDto(totalPages,totalElements,page,size,Collections.emptyList());
         }
 
-        int startIndex = page * size;
+        int startIndex = adjustedPage * size;
         int endIndex = Math.min(startIndex + size, (int) totalElements);
 
         List<RankingDto> pageContent;


### PR DESCRIPTION
<!-- Pull Request Template -->

# ✨ 작업내용
<!-- 이번 PR에서 수행한 주요 작업을 간단히 bullet로 기술 -->
- [ ] 빈 orderlist 반환 개선 + 9812ef881e5b6da6e062d9427a02e67ece60469d
---


# 🐞 이슈사항
<!-- 해결했거나 논의가 필요한 이슈 번호‧내용을 적어주세요 -->
| 이슈 번호 | 제목 | 상태 |
| :-- | :-- | :-- |
| #216 | api/userinfo/trades개선 | ✅ 해결 |

---


# ⚠️ 특별사항
<!-- 리뷰어에게 꼭 알리고 싶은 사항, 배포 전 확인할 점 등을 자유롭게 기재 -->
0-index 사용중이여서 계산식에 -1만 추가했습니다.
그리고 page의 defaultvalue는 1 로 변경하였습니다.
userinfo/trades랑 ranking/all 도 변경하였습니다.
